### PR TITLE
Replace docker scan with docker scout in the Image scanning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Want to add something? Open a PR :)
 
 ## Image scanning / Registry
 
-- [docker scan](https://docs.docker.com/engine/scan/)
+- [Docker Scout](https://docs.docker.com/scout/)
 - [AWS ECR Image Scanning](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
 - [Azure Container Registry scanning](https://azure.microsoft.com/en-us/updates/vulnerability-scanning-for-images-in-azure-container-registry-is-now-generally-available/)
 - [opa-docker-authz](https://github.com/open-policy-agent/opa-docker-authz) policy-enabled authorization plugin for Docker


### PR DESCRIPTION
The `docker scan` command has been removed since Apr 19, 2023 and has been replaced by `docker scout` (see https://github.com/docker/scan-cli-plugin/releases/tag/v0.26.0)