### PR TITLE
feat: add KubeStellar Console to Kubernetes section

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Want to add something? Open a PR :)
 - [kubeshark](https://github.com/kubeshark/kubeshark) think TCPDump and Wireshark re-invented for Kubernetes
 - [KubeHound](https://github.com/DataDog/KubeHound) is a Kubernetes attack graph tool allowing automated calculation of attack paths between assets in a cluster
 - [Marvin](https://github.com/undistro/marvin) is a CLI tool that scans a k8s cluster by performing CEL expressions to report potential issues, misconfigurations and vulnerabilities.
+- [KubeStellar Console](https://github.com/kubestellar/console) multi-cluster Kubernetes dashboard with security compliance dashboards, SBOM visibility, and supply chain security across edge and cloud clusters
 
 
 ## Runtime level security


### PR DESCRIPTION
[KubeStellar Console](https://github.com/kubestellar/console) is an open-source multi-cluster Kubernetes dashboard — CNCF Sandbox project with AI-powered operations, 20+ CNCF integrations (Argo, Kyverno, Istio, Prometheus), and real-time observability across edge and cloud.\n\n*Happy to adjust description or placement.*